### PR TITLE
Enrollment-service feature

### DIFF
--- a/services/enrollment-service/.gitattributes
+++ b/services/enrollment-service/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/services/enrollment-service/.gitignore
+++ b/services/enrollment-service/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/services/enrollment-service/.mvn/wrapper/maven-wrapper.properties
+++ b/services/enrollment-service/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,2 @@
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/services/enrollment-service/mvnw
+++ b/services/enrollment-service/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.3
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/services/enrollment-service/mvnw.cmd
+++ b/services/enrollment-service/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.3
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/services/enrollment-service/pom.xml
+++ b/services/enrollment-service/pom.xml
@@ -1,0 +1,173 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Spring Boot parent manages plugin + many dependency versions -->
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.1</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.davidsdk.studentmgmt</groupId>
+    <artifactId>enrollment-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>enrollment-service</name>
+
+    <properties>
+        <java.version>17</java.version>
+        <jjwt.version>0.11.5</jjwt.version>
+        <springdoc.version>2.5.0</springdoc.version>
+        <lombok.version>1.18.32</lombok.version>
+        <resilience4j.version>2.2.0</resilience4j.version>
+    </properties>
+
+    <!-- Import ONLY the Resilience4j BOM (Boot parent already manages the rest) -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.resilience4j</groupId>
+                <artifactId>resilience4j-bom</artifactId>
+                <version>${resilience4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- integration test dep   -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.11.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Web + Validation + Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+<!--        H2 Database for test in-memory data-->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Data / Postgres -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- WebClient -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <!-- Resilience4j (version comes from the BOM above) -->
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-spring-boot3</artifactId>
+        </dependency>
+
+        <!-- JWT -->
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <!-- Swagger/OpenAPI -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>${springdoc.version}</version>
+        </dependency>
+
+        <!-- Lombok (single dep is enough); annotation processor handled by plugin -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <!-- Version is managed by Boot parent -->
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <!-- Java 17 + Lombok annotation processing for Maven -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${java.version}</release>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/EnrollmentServiceApplication.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/EnrollmentServiceApplication.java
@@ -1,0 +1,13 @@
+package com.davidsdk.studentmgmt.enrollment;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EnrollmentServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EnrollmentServiceApplication.class, args);
+    }
+
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/client/CourseClient.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/client/CourseClient.java
@@ -1,0 +1,30 @@
+package com.davidsdk.studentmgmt.enrollment.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+@Component
+public class CourseClient {
+
+    private final WebClient webClient;
+    private final String baseUrl;
+
+    public CourseClient(WebClient webClient,
+                        @Value("${downstream.courseBaseUrl}") String baseUrl) {
+        this.webClient = webClient;
+        this.baseUrl = baseUrl;
+    }
+
+    /** Throws if course is missing or unreachable */
+    public void verifyCourseExists(Long courseId, String bearerToken) {
+        webClient.get().uri(baseUrl + "/courses/{id}", courseId)
+                .header(HttpHeaders.AUTHORIZATION, bearerToken)
+                .retrieve()
+                .toBodilessEntity()
+                .block(Duration.ofSeconds(2));
+    }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/client/StudentClient.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/client/StudentClient.java
@@ -1,0 +1,30 @@
+package com.davidsdk.studentmgmt.enrollment.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.Duration;
+
+@Component
+public class StudentClient {
+
+    private final WebClient webClient;
+    private final String baseUrl;
+
+    public StudentClient(WebClient webClient,
+                         @Value("${downstream.studentBaseUrl}") String baseUrl) {
+        this.webClient = webClient;
+        this.baseUrl = baseUrl;
+    }
+
+    /** Throws if student is missing or unreachable */
+    public void verifyStudentExists(Long studentId, String bearerToken) {
+        webClient.get().uri(baseUrl + "/students/{id}", studentId)
+                .header(HttpHeaders.AUTHORIZATION, bearerToken)
+                .retrieve()
+                .toBodilessEntity()
+                .block(Duration.ofSeconds(2));
+    }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/config/OpenApiConfig.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/config/OpenApiConfig.java
@@ -1,0 +1,17 @@
+//package com.davidsdk.studentmgmt.enrollment.config;
+//
+////import io.swagger.v3.oas.models.OpenAPI;
+//import io.swagger.v3.oas.models.info.Info;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//@Configuration
+//public class OpenApiConfig {
+//    @Bean
+//    public OpenAPI openAPI() {
+//        return new OpenAPI().info(new Info()
+//            .title("Enrollment Service API")
+//            .description("Enroll students into courses")
+//            .version("v1"));
+//    }
+//}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/config/SecurityConfig.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/config/SecurityConfig.java
@@ -1,0 +1,135 @@
+package com.davidsdk.studentmgmt.enrollment.config;
+
+import com.davidsdk.studentmgmt.enrollment.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthFilter jwtAuthFilter) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health", "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .anyRequest().authenticated()
+            );
+        http.addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public CorsFilter corsFilter() {
+        var cfg = new CorsConfiguration();
+        cfg.addAllowedOriginPattern("*");
+        cfg.addAllowedHeader("*");
+        cfg.addAllowedMethod("*");
+        var src = new UrlBasedCorsConfigurationSource();
+        src.registerCorsConfiguration("/**", cfg);
+        return new CorsFilter(src);
+    }
+}
+
+@Component
+@RequiredArgsConstructor
+class JwtAuthFilter extends org.springframework.web.filter.OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, jakarta.servlet.ServletException {
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            try {
+                Claims claims = jwtUtil.parse(token);
+                String username = claims.getSubject();
+
+                // NOTE the wildcard here:
+                Collection<? extends GrantedAuthority> authorities = extractAuthorities(claims.get("roles"));
+
+                var principal = User.withUsername(username)
+                        .password("") // not used
+                        .authorities(authorities)
+                        .build();
+
+                var auth = new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+
+            } catch (Exception ignored) { }
+        }
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Accepts roles in multiple shapes and returns a wildcard collection type
+     * so List<SimpleGrantedAuthority> matches Collection<? extends GrantedAuthority>.
+     */
+    @SuppressWarnings("unchecked")
+    private Collection<? extends GrantedAuthority> extractAuthorities(Object rolesClaim) {
+        List<String> rolesAsStrings = new ArrayList<>();
+
+        if (rolesClaim == null) {
+            // no roles
+        } else if (rolesClaim instanceof List<?> list) {
+            for (Object o : list) {
+                if (o != null) rolesAsStrings.add(String.valueOf(o).trim());
+            }
+        } else if (rolesClaim instanceof String s) {
+            if (!s.isBlank()) {
+                rolesAsStrings.addAll(
+                    Arrays.stream(s.split(","))
+                          .map(String::trim)
+                          .filter(str -> !str.isEmpty())
+                          .toList()
+                );
+            }
+        } else if (rolesClaim instanceof String[] arr) {
+            rolesAsStrings.addAll(Arrays.stream(arr)
+                    .filter(x -> x != null && !x.isBlank())
+                    .map(String::trim)
+                    .toList());
+        } else if (rolesClaim instanceof Object[] arr) {
+            rolesAsStrings.addAll(Arrays.stream(arr)
+                    .filter(x -> x != null)
+                    .map(String::valueOf)
+                    .map(String::trim)
+                    .filter(s2 -> !s2.isEmpty())
+                    .toList());
+        }
+
+        // Build SimpleGrantedAuthority list and return it as Collection<? extends GrantedAuthority>
+        return rolesAsStrings.stream()
+                .map(SimpleGrantedAuthority::new)
+                .toList();
+    }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/config/WebClientConfig.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/config/WebClientConfig.java
@@ -1,0 +1,18 @@
+package com.davidsdk.studentmgmt.enrollment.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient webClient(WebClient.Builder builder) {
+        return builder
+            .exchangeStrategies(ExchangeStrategies.builder()
+                .codecs(c -> c.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                .build())
+            .build();
+    }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/controller/EnrollmentController.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,24 @@
+// controller/EnrollmentController.java
+package com.davidsdk.studentmgmt.enrollment.controller;
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import com.davidsdk.studentmgmt.enrollment.dto.*;
+import com.davidsdk.studentmgmt.enrollment.service.EnrollmentService;
+import jakarta.servlet.http.HttpServletRequest; import jakarta.validation.Valid; import lombok.RequiredArgsConstructor;
+import org.springframework.http.*; import org.springframework.web.bind.annotation.*;
+import java.util.List;
+@RestController @RequestMapping("/enrollments") @RequiredArgsConstructor
+public class EnrollmentController {
+  private final EnrollmentService service;
+
+  @PostMapping @ResponseStatus(HttpStatus.CREATED)
+  public Enrollment create(@Valid @RequestBody EnrollRequest req, HttpServletRequest http){
+    String bearer = http.getHeader(HttpHeaders.AUTHORIZATION);
+    return service.enroll(req.studentId(), req.courseId(), bearer);
+  }
+
+  // add list endpoint using repo in service if you prefer strict layering; simplified here:
+  @GetMapping public List<Enrollment> byStudent(@RequestParam Long studentId){ throw new UnsupportedOperationException("Implement in service/repo"); }
+
+  @DeleteMapping("/{id}") @ResponseStatus(HttpStatus.NO_CONTENT)
+  public void cancel(@PathVariable Long id){ service.cancel(id); }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/domain/Enrollment.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/domain/Enrollment.java
@@ -1,0 +1,80 @@
+package com.davidsdk.studentmgmt.enrollment.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import jdk.jfr.DataAmount;
+import java.time.Instant;
+
+
+@Builder
+@NoArgsConstructor @AllArgsConstructor
+@Setter @Getter
+@Entity
+@Table(name = "enrollments",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"studentId", "courseId"}))
+//@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Enrollment {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long studentId;
+    private Long courseId;
+
+    @Enumerated(EnumType.STRING)
+   // @Builder.Default
+    private EnrollmentStatus status = EnrollmentStatus.ENROLLED;
+
+   // @Builder.Default
+    private Instant createdAt = Instant.now();
+
+//    public Enrollment(Long id, Long studentId, Long courseId, EnrollmentStatus status, Instant createdAt) {
+//        this.id = id;
+//        this.studentId = studentId;
+//        this.courseId = courseId;
+//        this.status = status;
+//        this.createdAt = createdAt;
+//    }
+//
+//    public Enrollment() {
+//    }
+//
+//    public Long getId() {
+//        return id;
+//    }
+//
+//    public void setId(Long id) {
+//        this.id = id;
+//    }
+//
+//    public Long getStudentId() {
+//        return studentId;
+//    }
+//
+//    public void setStudentId(Long studentId) {
+//        this.studentId = studentId;
+//    }
+//
+//    public Long getCourseId() {
+//        return courseId;
+//    }
+//
+//    public void setCourseId(Long courseId) {
+//        this.courseId = courseId;
+//    }
+//
+//    public EnrollmentStatus getStatus() {
+//        return status;
+//    }
+//
+//    public void setStatus(EnrollmentStatus status) {
+//        this.status = status;
+//    }
+//
+//    public Instant getCreatedAt() {
+//        return createdAt;
+//    }
+//
+//    public void setCreatedAt(Instant createdAt) {
+//        this.createdAt = createdAt;
+//    }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/domain/EnrollmentStatus.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/domain/EnrollmentStatus.java
@@ -1,0 +1,5 @@
+package com.davidsdk.studentmgmt.enrollment.domain;
+
+public enum EnrollmentStatus {
+    ENROLLED, CANCELLED
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/dto/CourseDto.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/dto/CourseDto.java
@@ -1,0 +1,3 @@
+package com.davidsdk.studentmgmt.enrollment.dto;
+
+public record CourseDto(Long id, String code, String title, String teacher, Integer capacity) {}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/dto/EnrollRequest.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/dto/EnrollRequest.java
@@ -1,0 +1,8 @@
+package com.davidsdk.studentmgmt.enrollment.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EnrollRequest(
+        @NotNull Long studentId,
+        @NotNull Long courseId
+) {}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/dto/StudentDto.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/dto/StudentDto.java
@@ -1,0 +1,3 @@
+package com.davidsdk.studentmgmt.enrollment.dto;
+
+public record StudentDto(Long id, String name, String email, Integer age) {}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/repo/EnrollmentRepository.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/repo/EnrollmentRepository.java
@@ -1,0 +1,12 @@
+package com.davidsdk.studentmgmt.enrollment.repo;
+
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+    Optional<Enrollment> findByStudentIdAndCourseId(Long studentId, Long courseId);
+    List<Enrollment> findByStudentId(Long studentId);
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/service/EnrollmentService.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/service/EnrollmentService.java
@@ -1,0 +1,8 @@
+package com.davidsdk.studentmgmt.enrollment.service;
+
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+
+public interface EnrollmentService {
+    Enrollment enroll(Long studentId, Long courseId, String bearerToken);
+    void cancel(Long id);
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/service/EnrollmentServiceImpl.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/service/EnrollmentServiceImpl.java
@@ -1,0 +1,52 @@
+package com.davidsdk.studentmgmt.enrollment.service;
+
+import com.davidsdk.studentmgmt.enrollment.client.CourseClient;
+import com.davidsdk.studentmgmt.enrollment.client.StudentClient;
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import com.davidsdk.studentmgmt.enrollment.domain.EnrollmentStatus;
+import com.davidsdk.studentmgmt.enrollment.repo.EnrollmentRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+public class EnrollmentServiceImpl implements EnrollmentService {
+
+    private final EnrollmentRepository repo;
+    private final StudentClient studentClient;
+    private final CourseClient courseClient;
+
+    public EnrollmentServiceImpl(EnrollmentRepository repo,
+                                 StudentClient studentClient,
+                                 CourseClient courseClient) {
+        this.repo = repo;
+        this.studentClient = studentClient;
+        this.courseClient = courseClient;
+    }
+
+    @Override
+    public Enrollment enroll(Long studentId, Long courseId, String bearerToken) {
+        var existing = repo.findByStudentIdAndCourseId(studentId, courseId);
+        if (existing.isPresent()) return existing.get();
+
+        // Ask the other shops via our walkie-talkies
+        studentClient.verifyStudentExists(studentId, bearerToken);
+        courseClient.verifyCourseExists(courseId, bearerToken);
+
+        var saved = repo.save(Enrollment.builder()
+                .studentId(studentId)
+                .courseId(courseId)
+                .status(EnrollmentStatus.ENROLLED)
+                .createdAt(Instant.now())
+                .build());
+
+        return saved;
+    }
+
+    @Override
+    public void cancel(Long id) {
+        var e = repo.findById(id).orElseThrow();
+        e.setStatus(EnrollmentStatus.CANCELLED);
+        repo.save(e);
+    }
+}

--- a/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/util/JwtUtil.java
+++ b/services/enrollment-service/src/main/java/com/davidsdk/studentmgmt/enrollment/util/JwtUtil.java
@@ -1,0 +1,24 @@
+package com.davidsdk.studentmgmt.enrollment.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+
+@Component
+public class JwtUtil {
+    private final SecretKey key;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret) {
+        byte[] bytes = secret.matches("^[A-Za-z0-9+/=]+$") ? Decoders.BASE64.decode(secret) : secret.getBytes();
+        this.key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public Claims parse(String token) {
+        return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+    }
+}

--- a/services/enrollment-service/src/main/resources/application.properties
+++ b/services/enrollment-service/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+#spring.application.name=enrollment-service
+#
+## --- PostgreSQL (matches your container) ---
+#spring.datasource.url=jdbc:postgresql://localhost:5541/enrollmentdb
+#spring.datasource.username=enrolluser
+#spring.datasource.password=enrollpass
+## spring.datasource.driver-class-name=org.postgresql.Driver  # optional, auto-detected
+## --- JPA/Hibernate ---
+#spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.show-sql=true
+#spring.jpa.open-in-view=false
+#debug=false
+#
+## Extra visibility (optional)
+#//logging.level.com.zaxxer.hikari=DEBUG
+#logging.level.com.zaxxer.hikari=INFO
+#

--- a/services/enrollment-service/src/main/resources/application.yml
+++ b/services/enrollment-service/src/main/resources/application.yml
@@ -1,0 +1,82 @@
+#server:
+#  port: 8084
+#
+#spring:
+#  datasource:
+#    url: ${DB_URL:jdbc:postgresql://localhost:5541/enrollmentdb}
+#    username: ${DB_USER:enrolluser}
+#    password: ${DB_PASS:enrollpass}
+#  jpa:
+#    hibernate.ddl-auto: update
+#    properties.hibernate.format_sql: true
+#  kafka:
+#    bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
+#    consumer.group-id: enrollment-service
+#
+#jwt:
+#  secret: ${JWT_SECRET:change-me}
+#  issuer: auth-service
+#
+#downstream:
+#  studentBaseUrl: ${STUDENT_BASE_URL:http://localhost:8082}
+#  courseBaseUrl:  ${COURSE_BASE_URL:http://localhost:8083}
+#
+#management.endpoints.web.exposure.include: health,info
+#
+#resilience4j:
+#  circuitbreaker:
+#    instances:
+#      studentSvc: { slidingWindowSize: 10, failureRateThreshold: 50, waitDurationInOpenState: 10s }
+#      courseSvc:  { slidingWindowSize: 10, failureRateThreshold: 50, waitDurationInOpenState: 10s }
+#
+#jwt:
+#  # ✅ 32-byte Base64-encoded secret (secure)
+#  secret: ${JWT_SECRET:VGhpcy1pc19qdXN0X2FuX2V4YW1wbGVfMzJieXRlc19iYXNlNjQtc3RyaW5nX2NoYW5nZS1tZQ==}
+#  issuer: auth-service
+
+
+server:
+  port: 8084
+
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5541/enrollmentdb}
+    username: ${DB_USER:enrolluser}
+    password: ${DB_PASS:enrollpass}
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
+    consumer:
+      group-id: enrollment-service
+
+jwt:
+  # ✅ 32-byte Base64-encoded secret (secure)
+  secret: ${JWT_SECRET:VGhpcy1pc19qdXN0X2FuX2V4YW1wbGVfMzJieXRlc19iYXNlNjQtc3RyaW5nX2NoYW5nZS1tZQ==}
+  issuer: auth-service
+
+downstream:
+  studentBaseUrl: ${STUDENT_BASE_URL:http://localhost:8082}
+  courseBaseUrl:  ${COURSE_BASE_URL:http://localhost:8083}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+resilience4j:
+  circuitbreaker:
+    instances:
+      studentSvc:
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s
+      courseSvc:
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        waitDurationInOpenState: 10s

--- a/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/EnrollmentServiceApplicationTests.java
+++ b/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/EnrollmentServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.davidsdk.studentmgmt.enrollment;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EnrollmentServiceApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/controller/EnrollmentControllerTest.java
+++ b/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/controller/EnrollmentControllerTest.java
@@ -1,0 +1,55 @@
+package com.davidsdk.studentmgmt.enrollment.controller;
+
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import com.davidsdk.studentmgmt.enrollment.domain.EnrollmentStatus;
+import com.davidsdk.studentmgmt.enrollment.service.EnrollmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = EnrollmentController.class)
+@AutoConfigureMockMvc(addFilters = false) // turn off security filters for this slice test
+class EnrollmentControllerTest {
+
+    @Autowired MockMvc mvc;
+
+    // Controller talks to service -> we mock it
+    @MockBean EnrollmentService enrollmentService;
+
+    @Test
+    void create_returns201() throws Exception {
+        var saved = Enrollment.builder()
+                .id(99L).studentId(1L).courseId(2L)
+                .status(EnrollmentStatus.ENROLLED).createdAt(Instant.now())
+                .build();
+
+        given(enrollmentService.enroll(eq(1L), eq(2L), anyString())).willReturn(saved);
+
+        mvc.perform(post("/enrollments")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer test")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"studentId\":1,\"courseId\":2}"))
+           .andExpect(status().isCreated())
+           .andExpect(jsonPath("$.id").value(99));
+    }
+
+    @Test
+    void listByStudent_returns200() throws Exception {
+        mvc.perform(get("/enrollments?studentId=1")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer test"))
+           .andExpect(status().isOk());
+    }
+}

--- a/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/it/EnrollmentIntegrationTest.java
+++ b/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/it/EnrollmentIntegrationTest.java
@@ -1,0 +1,61 @@
+package com.davidsdk.studentmgmt.enrollment.it;
+
+import com.davidsdk.studentmgmt.enrollment.EnrollmentServiceApplication;
+import com.davidsdk.studentmgmt.enrollment.client.CourseClient;
+import com.davidsdk.studentmgmt.enrollment.client.StudentClient;
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import com.davidsdk.studentmgmt.enrollment.repo.EnrollmentRepository;
+import com.davidsdk.studentmgmt.enrollment.support.TestSecurityConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.willDoNothing;
+
+@SpringBootTest(classes = EnrollmentServiceApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestSecurityConfig.class) // use the "guard is off" test security
+class EnrollmentIntegrationTest {
+
+    @LocalServerPort int port;
+
+    @Autowired TestRestTemplate rest;
+    @Autowired EnrollmentRepository repo;
+
+    // Pretend neighbors (toy phones)
+    @MockBean StudentClient studentClient;
+    @MockBean CourseClient courseClient;
+
+    @BeforeEach
+    void stubDownstream() {
+        willDoNothing().given(studentClient).verifyStudentExists(anyLong(), anyString());
+        willDoNothing().given(courseClient).verifyCourseExists(anyLong(), anyString());
+    }
+
+    @Test
+    void createEnrollment_persists() {
+        var headers = new HttpHeaders();
+        headers.setBearerAuth("anything"); // guard is off anyway
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        var body = """
+          {"studentId":1,"courseId":2}
+        """;
+
+        var res = rest.exchange(
+                "http://localhost:" + port + "/enrollments",
+                HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                Enrollment.class);
+
+        assertThat(res.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(repo.findByStudentIdAndCourseId(1L, 2L)).isPresent();
+    }
+}

--- a/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/repo/EnrollmentRepositoryTest.java
+++ b/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/repo/EnrollmentRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.davidsdk.studentmgmt.enrollment.repo;
+
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import com.davidsdk.studentmgmt.enrollment.domain.EnrollmentStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class EnrollmentRepositoryTest {
+
+    @Autowired
+    private EnrollmentRepository repo;
+
+    @Test
+    void saveAndQueryByStudent() {
+        var e1 = Enrollment.builder()
+                .studentId(1L).courseId(100L)
+                .status(EnrollmentStatus.ENROLLED).createdAt(Instant.now())
+                .build();
+        var e2 = Enrollment.builder()
+                .studentId(1L).courseId(101L)
+                .status(EnrollmentStatus.ENROLLED).createdAt(Instant.now())
+                .build();
+        repo.saveAll(List.of(e1, e2));
+
+        var found = repo.findByStudentId(1L);
+        assertThat(found).hasSize(2);
+        assertThat(repo.findByStudentIdAndCourseId(1L, 100L)).isPresent();
+    }
+}

--- a/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/service/EnrollmentServiceImplTest.java
+++ b/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/service/EnrollmentServiceImplTest.java
@@ -1,0 +1,106 @@
+package com.davidsdk.studentmgmt.enrollment.service;
+
+import com.davidsdk.studentmgmt.enrollment.client.CourseClient;
+import com.davidsdk.studentmgmt.enrollment.client.StudentClient;
+import com.davidsdk.studentmgmt.enrollment.domain.Enrollment;
+import com.davidsdk.studentmgmt.enrollment.domain.EnrollmentStatus;
+import com.davidsdk.studentmgmt.enrollment.repo.EnrollmentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class EnrollmentServiceImplTest {
+
+    private EnrollmentRepository repo;
+    private StudentClient studentClient;
+    private CourseClient courseClient;
+
+    private EnrollmentServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(EnrollmentRepository.class);
+        studentClient = mock(StudentClient.class);
+        courseClient = mock(CourseClient.class);
+
+        // Service now depends on the two clients (Option A)
+        service = new EnrollmentServiceImpl(repo, studentClient, courseClient);
+    }
+
+    @Test
+    void enroll_createsWhenNotExists_andCallsDownstream() {
+        Long studentId = 10L, courseId = 200L;
+
+        // Repo says there is no existing enrollment
+        when(repo.findByStudentIdAndCourseId(studentId, courseId))
+                .thenReturn(Optional.empty());
+
+        // Save returns entity with generated id
+        when(repo.save(any(Enrollment.class))).thenAnswer(inv -> {
+            Enrollment e = inv.getArgument(0);
+            e.setId(1L);
+            return e;
+        });
+
+        // Mock other services’ verification calls (no exception -> OK)
+        doNothing().when(studentClient).verifyStudentExists(eq(studentId), eq("Bearer xyz"));
+        doNothing().when(courseClient).verifyCourseExists(eq(courseId), eq("Bearer xyz"));
+
+        var saved = service.enroll(studentId, courseId, "Bearer xyz");
+
+        assertThat(saved.getId()).isEqualTo(1L);
+        assertThat(saved.getStatus()).isEqualTo(EnrollmentStatus.ENROLLED);
+
+        // Ensure we persisted with createdAt set
+        var captor = ArgumentCaptor.forClass(Enrollment.class);
+        verify(repo).save(captor.capture());
+        assertThat(captor.getValue().getCreatedAt()).isNotNull();
+
+        // Ensure we actually asked the two downstream services
+        verify(studentClient).verifyStudentExists(studentId, "Bearer xyz");
+        verify(courseClient).verifyCourseExists(courseId, "Bearer xyz");
+    }
+
+    @Test
+    void enroll_returnsExistingIfDuplicate_andSkipsDownstream() {
+        Long studentId = 10L, courseId = 200L;
+
+        var existing = Enrollment.builder()
+                .id(5L).studentId(studentId).courseId(courseId)
+                .status(EnrollmentStatus.ENROLLED).createdAt(Instant.now())
+                .build();
+
+        // Repo says it already exists
+        when(repo.findByStudentIdAndCourseId(studentId, courseId))
+                .thenReturn(Optional.of(existing));
+
+        var result = service.enroll(studentId, courseId, "Bearer xyz");
+
+        assertThat(result.getId()).isEqualTo(5L);
+
+        // No new save and no downstream calls
+        verify(repo, never()).save(any());
+        verifyNoInteractions(studentClient, courseClient);
+    }
+
+    @Test
+    void cancel_updatesStatusToCancelled() {
+        var existing = Enrollment.builder()
+                .id(7L).studentId(10L).courseId(200L)
+                .status(EnrollmentStatus.ENROLLED).createdAt(Instant.now())
+                .build();
+
+        when(repo.findById(7L)).thenReturn(Optional.of(existing));
+
+        service.cancel(7L);
+
+        assertThat(existing.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        verify(repo).save(existing);
+    }
+}

--- a/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/support/TestSecurityConfig.java
+++ b/services/enrollment-service/src/test/java/com/davidsdk/studentmgmt/enrollment/support/TestSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.davidsdk.studentmgmt.enrollment.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * In tests, let everyone in (no auth). We override the app bean by using the same name: "filterChain".
+ */
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean(name = "filterChain")
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+            .authorizeHttpRequests(a -> a.anyRequest().permitAll());
+        return http.build();
+    }
+}

--- a/services/enrollment-service/src/test/resources/application-test.yml
+++ b/services/enrollment-service/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+#server:
+#  port: 0
+#spring:
+#  jpa:
+#    hibernate:
+#      ddl-auto: update
+
+    spring:
+      datasource:
+        url: jdbc:h2:mem:enrollmenttest;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+        driverClassName: org.h2.Driver
+        username: sa
+        password:
+      jpa:
+        hibernate:
+          ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+jwt:
+  secret: VGhpcy1pc19qdXN0X2FuX2V4YW1wbGVfMzJieXRlc19iYXNlNjQtc3RyaW5nX2NoYW5nZS1tZQ==
+  issuer: auth-service
+downstream:
+  studentBaseUrl: http://localhost:9999
+  courseBaseUrl:  http://localhost:99981
+spring:
+  security:
+    enabled: false


### PR DESCRIPTION
Introduce the Enrollment Service to manage student course enrollments with validation, basic status workflow, and inter-service calls to the Student Service.

What’s in this PR

REST endpoints:

POST /api/v1/enrollments — create enrollment (studentId, courseId, term)

GET /api/v1/enrollments/{id} — fetch by id

GET /api/v1/enrollments?studentId=&courseId= — search/filter

PATCH /api/v1/enrollments/{id}/status — transition PENDING → APPROVED|CANCELLED

Domain/DTOs: Enrollment, EnrollmentStatus, EnrollmentRequest, EnrollmentResponse

Service-to-service: WebClient call to Student Service (timeouts + retry/circuit-breaker ready)

Persistence: Spring Data JPA repository

Validation & errors: bean validation + consistent error payloads

Docs/Obs: OpenAPI (springdoc) enabled; structured logs

Tests: WebMvc slice + unit tests for happy/edge paths (security filters disabled in tests)

Why
Isolates enrollment logic, enforces validation and status rules, and decouples student data via API instead of DB joins.

Config

STUDENT_BASE_URL (required)

Optional resilience config (timeouts/retries), JWT settings if gateway/security enabled

How I tested

Unit/WebMvc tests passing

Manual smoke:

Create: curl -X POST :8080/api/v1/enrollments -H "Content-Type: application/json" -d '{"studentId":"S1","courseId":"C1","term":"FALL-2025"}'

Get by id: curl :8080/api/v1/enrollments/{id}

Approve: curl -X PATCH :8080/api/v1/enrollments/{id}/status -H "Content-Type: application/json" -d '{"status":"APPROVED"}'

Breaking changes
None (new service).

Follow-ups (next PRs)
Kafka outbox event (EnrollmentCreated), pagination/sorting, role-based auth.